### PR TITLE
TS/JS language support; Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,31 +56,25 @@ git clone https://github.com/sourcegraph/sublime-lsp
 Install the `langserver-go` binary by running `go get -u github.com/sourcegraph/go-langserver/langserver/cmd/langserver-go`. The `langserver-go` binary should now be available via your command line.
 
 Next, configure the LSP connector for the `langserver-go` binary. To change your Sourcegraph settings, open `SublimeLsp.sublime-settings` by clicking `Sublime Text > Preferences > Package Settings > Sublime Lsp Connector > Settings - User`.
-Find there `clients` section, if it does not exist, create it the following way
+
+Add the following client descriptor into `clients` section
 
 ```
 {
-...
-    "clients": [
-    ]
-...
-}
-```
-
-Then, add the following client descriptor into `clients` section
-
-```
-{
-        {
-            "binary": "langserver-go",
-            "file_exts": ["go"],
-            // the go binary must be in the path
-            "path_additions": ["/usr/local/go/bin"],
-            "env": {
-                // GOPATH is a required argument, ~'s don't work
-                "GOPATH": "",
+    ...
+        "clients": [
+            {
+                "binary": "langserver-go",
+                "file_exts": ["go"],
+                // the go binary must be in the path
+                "path_additions": ["/usr/local/go/bin"],
+                "env": {
+                    // GOPATH is a required argument, ~'s don't work
+                    "GOPATH": "",
+                }
             }
-        }
+        ]
+    ....
 }
 ```
 
@@ -120,25 +114,19 @@ node_modules/.bin/tsc
 Please make sure that `$JSTS_DIR/bin` is in `$PATH`
 
 Next, register TypeScript/JavaScript LSP client. To change your Sourcegraph settings, open `SublimeLsp.sublime-settings` by clicking `Sublime Text > Preferences > Package Settings > Sublime Lsp Connector > Settings - User`.
-Find there `clients` section, if it does not exist, create it the following way
+
+Add the following client descriptor into `clients` section
 
 ```
 {
-...
-    "clients": [
+    ...
+        "clients": [
+            {
+                "binary": "javascript-typescript-stdio",
+                "file_exts": ["ts", "tsx", "js", "jsx"]
+            }
     ]
-...
-}
-```
-
-Then, add the following client descriptor into `clients` section
-
-```
-{
-        {
-            "binary": "javascript-typescript-sublime",
-            "file_exts": ["ts", "tsx", "js", "jsx"]
-        }
+    ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,26 @@ Finally, restart Sublime Text to start using the plugin. You may want to [disabl
 
 ### TypeScript/JavaScript installation
 
-Install the TypeScript/JavaScript LSP server the following way:
+First, you need to add TypeScript Sublime support the following way:
+
+```shell
+git clone git clone https://github.com/Microsoft/TypeScript-TmLanguage ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/TypeScript-TmLanguage
+```
+
+Linux:
+
+```shell
+git clone https://github.com/Microsoft/TypeScript-TmLanguage ~/.config/sublime-text-3/Packages/TypeScript-TmLanguage
+```
+
+Windows:
+
+```bat
+cd "%APPDATA%\Sublime Text 3\Packages"
+git clone https://github.com/Microsoft/TypeScript-TmLanguage
+```
+
+Then install the TypeScript/JavaScript LSP server the following way:
 
 ```shell
 export JSTS_DIR=...

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Install the `langserver-go` binary by running `go get -u github.com/sourcegraph/
 Next, configure the LSP connector for the `langserver-go` binary. To change your Sourcegraph settings, open `SublimeLsp.sublime-settings` by clicking `Sublime Text > Preferences > Package Settings > Sublime Lsp Connector > Settings - User`.
 Find there `clients` section, if it does not exist, create it the following way
 
-```json
+```
 {
 ...
     "clients": [
@@ -69,7 +69,7 @@ Find there `clients` section, if it does not exist, create it the following way
 
 Then, add the following client descriptor into `clients` section
 
-```json
+```
 {
         {
             "binary": "langserver-go",
@@ -122,7 +122,7 @@ Please make sure that `$JSTS_DIR/bin` is in `$PATH`
 Next, register TypeScript/JavaScript LSP client. To change your Sourcegraph settings, open `SublimeLsp.sublime-settings` by clicking `Sublime Text > Preferences > Package Settings > Sublime Lsp Connector > Settings - User`.
 Find there `clients` section, if it does not exist, create it the following way
 
-```json
+```
 {
 ...
     "clients": [
@@ -133,7 +133,7 @@ Find there `clients` section, if it does not exist, create it the following way
 
 Then, add the following client descriptor into `clients` section
 
-```json
+```
 {
         {
             "binary": "javascript-typescript-sublime",

--- a/README.md
+++ b/README.md
@@ -28,11 +28,9 @@ This plugin has been developed for use with the [go-langserver](https://github.c
 
 ## Installation
 
-### Go installation
+### Connector installation
 
-First, install the `langserver-go` binary by running `go get -u github.com/sourcegraph/go-langserver/langserver/cmd/langserver-go`. The `langserver-go` binary should now be available via your command line.
-
-Next, install the `lsp-sublime` connector for Sublime Text by cloning `lsp-sublime` repository into your Sublime Text 3 Packages folder:
+Install the `lsp-sublime` connector for Sublime Text by cloning `lsp-sublime` repository into your Sublime Text 3 Packages folder:
 
 macOS:
 
@@ -46,12 +44,33 @@ Linux:
 git clone git@github.com:sourcegraph/lsp-sublime.git ~/.config/sublime-text-3/Packages/lsp-sublime
 ```
 
-Next, configure the LSP connector for the `langserver-go` binary. To change your Sourcegraph settings, open `SublimeLsp.sublime-settings` by clicking `Sublime Text > Preferences > Package Settings > Sublime Lsp Connector > Settings - User`.
+Windows:
 
+```bat
+cd "%APPDATA%\Sublime Text 3\Packages"
+git clone https://github.com/sourcegraph/sublime-lsp
 ```
+
+### Go installation
+
+Install the `langserver-go` binary by running `go get -u github.com/sourcegraph/go-langserver/langserver/cmd/langserver-go`. The `langserver-go` binary should now be available via your command line.
+
+Next, configure the LSP connector for the `langserver-go` binary. To change your Sourcegraph settings, open `SublimeLsp.sublime-settings` by clicking `Sublime Text > Preferences > Package Settings > Sublime Lsp Connector > Settings - User`.
+Find there `clients` section, if it does not exist, create it the following way
+
+```json
 {
-    ...
+...
     "clients": [
+    ]
+...
+}
+```
+
+Then, add the following client descriptor into `clients` section
+
+```json
+{
         {
             "binary": "langserver-go",
             "file_exts": ["go"],
@@ -62,12 +81,50 @@ Next, configure the LSP connector for the `langserver-go` binary. To change your
                 "GOPATH": "",
             }
         }
-    ]
-    ...
 }
 ```
 
 Finally, restart Sublime Text to start using the plugin. You may want to [disable Sublime's native tooltips](https://github.com/sourcegraph/lsp-sublime#remove-sublime-text-3-tooltips-and-goto-menu-items), as they are duplicative and interfere with this connector's tooltips.  
+
+### TypeScript/JavaScript installation
+
+Install the TypeScript/JavaScript LSP server the following way:
+
+```shell
+export JSTS_DIR=...
+git clone https://github.com/sourcegraph/javascript-typescript-langserver $JSTS_DIR
+cd $JSTS_DIR
+npm install
+node_modules/.bin/tsc
+```
+
+Please make sure that `$JSTS_DIR/bin` is in `$PATH`
+
+Next, register TypeScript/JavaScript LSP client. To change your Sourcegraph settings, open `SublimeLsp.sublime-settings` by clicking `Sublime Text > Preferences > Package Settings > Sublime Lsp Connector > Settings - User`.
+Find there `clients` section, if it does not exist, create it the following way
+
+```json
+{
+...
+    "clients": [
+    ]
+...
+}
+```
+
+Then, add the following client descriptor into `clients` section
+
+```json
+{
+        {
+            "binary": "javascript-typescript-sublime",
+            "file_exts": ["ts", "tsx", "js", "jsx"]
+        }
+}
+```
+
+Finally, restart Sublime Text to start using the plugin. You may want to [disable Sublime's native tooltips](https://github.com/sourcegraph/lsp-sublime#remove-sublime-text-3-tooltips-and-goto-menu-items), as they are duplicative and interfere with this connector's tooltips.  
+
 
 ## Usage
 

--- a/typescript/commands/references.py
+++ b/typescript/commands/references.py
@@ -5,6 +5,7 @@ import sublime_plugin
 from ..libs import *
 from ..libs.view_helpers import *
 from ..libs.reference import *
+from ..libs import log
 from .base_command import TypeScriptBaseTextCommand
 
 
@@ -201,8 +202,8 @@ class RefsHelper:
         """ returns text of the given line in the given file """
         lines = self.__table(fileName)
         l = len(lines)
-        if l < line:
-            return ''
+        if l <= line:
+            return 'Error fetching preview from %s' % (fileName)
         content = self.__content[fileName]
         start = lines[line]
         if line < l - 1:
@@ -216,17 +217,21 @@ class RefsHelper:
         lines = self.__lines.get(fileName)
         if lines is not None:
             return lines
-        f = open(fileName)
         lines = []
         offset = 0
         content = ''
+        f = None
         try:
+            f = open(fileName, encoding='utf-8', errors='ignore')
             for line in f:
                 lines.append(offset)
                 offset += len(line)
                 content += line
+        except Exception as e:
+            log.exception('Error fetching preview from %s' % (fileName))
         finally:
-            f.close()
+            if f is not None:
+                f.close()
             self.__lines[fileName] = lines
             self.__content[fileName] = content
         return lines

--- a/typescript/commands/references.py
+++ b/typescript/commands/references.py
@@ -7,6 +7,7 @@ from ..libs.view_helpers import *
 from ..libs.reference import *
 from ..libs import log
 from .base_command import TypeScriptBaseTextCommand
+from collections import defaultdict
 
 
 class TypescriptFindReferencesCommand(TypeScriptBaseTextCommand):
@@ -42,11 +43,14 @@ class TypescriptFindReferencesCommand(TypeScriptBaseTextCommand):
     def __decorate(file_name, line, references):
         helper = RefsHelper()
         symbol = None
+        file_entries = defaultdict(list)
         for i, entry in enumerate(references["refs"]):
-            line = helper.lineText(entry["file"], entry["start"]["line"] - 1)
-            if symbol is None and entry["start"]["line"] == entry["end"]["line"]:
-                symbol = line[entry["start"]["offset"]-1:entry["end"]["offset"]-1]
-            references["refs"][i]["lineText"] = line
+            file_entries[entry["file"]].append(entry)
+        for file_name in file_entries:
+            get_lines_from_file(file_name, file_entries[file_name])
+            for entry in file_entries[file_name]:
+                if symbol is None and entry["start"]["line"] == entry["end"]["line"]:
+                    symbol = entry["lineText"][entry["start"]["offset"]-1:entry["end"]["offset"]-1]
         if symbol is None:
             symbol = "?"
         references["symbolName"] = symbol
@@ -193,45 +197,23 @@ class TypescriptPopulateRefs(sublime_plugin.TextCommand):
         self.view.settings().set('refinfo', ref_info.as_value())
         self.view.set_read_only(True)
 
-class RefsHelper:
 
-    __lines = {}
-    __content = {}
+def get_lines_from_file(fileName, entries):
+    line_nos = defaultdict(list)
+    for entry in entries:
+        line_nos[entry["start"]["line"] - 1].append(entry)
+    f = None
+    try:
+        f = open(fileName, encoding='utf-8', errors='ignore')
+        count = 0
+        for line in f:
+            if line_nos.get(count):
+                for entry in line_nos.get(count):
+                    entry["lineText"] = line.rstrip()
+            count = count + 1
 
-    def lineText(self, fileName, line):
-        """ returns text of the given line in the given file """
-        lines = self.__table(fileName)
-        l = len(lines)
-        if l <= line:
-            return 'Error fetching preview from %s' % (fileName)
-        content = self.__content[fileName]
-        start = lines[line]
-        if line < l - 1:
-            end = lines[line + 1]
-        else:
-            end = len(content)
-        return content[start:end].rstrip()
-
-    def __table(self, fileName):
-        """ returns line table for a given filename, computes if needed """
-        lines = self.__lines.get(fileName)
-        if lines is not None:
-            return lines
-        lines = []
-        offset = 0
-        content = ''
-        f = None
-        try:
-            f = open(fileName, encoding='utf-8', errors='ignore')
-            for line in f:
-                lines.append(offset)
-                offset += len(line)
-                content += line
-        except Exception as e:
-            log.exception('Error fetching preview from %s' % (fileName))
-        finally:
-            if f is not None:
-                f.close()
-            self.__lines[fileName] = lines
-            self.__content[fileName] = content
-        return lines
+    except Exception as e:
+        log.exception('Error fetching preview from %s' % (fileName))
+    finally:
+        if f is not None:
+            f.close()

--- a/typescript/commands/references.py
+++ b/typescript/commands/references.py
@@ -41,7 +41,6 @@ class TypescriptFindReferencesCommand(TypeScriptBaseTextCommand):
 
     @staticmethod
     def __decorate(file_name, line, references):
-        helper = RefsHelper()
         symbol = None
         file_entries = defaultdict(list)
         for i, entry in enumerate(references["refs"]):

--- a/typescript/commands/references.py
+++ b/typescript/commands/references.py
@@ -119,7 +119,7 @@ class TypescriptPopulateRefs(sublime_plugin.TextCommand):
         args = json_helpers.decode(argsJson)
         file_name = args["filename"]
         line = args["line"]
-        ref_display_string = args["referencesRespBody"]["symbolDisplayString"]
+        ref_display_string = args["referencesRespBody"]["symbolName"]
         ref_id = args["referencesRespBody"]["symbolName"]
         refs = args["referencesRespBody"]["refs"]
 

--- a/typescript/libs/lsp_client.py
+++ b/typescript/libs/lsp_client.py
@@ -14,6 +14,7 @@ from . import json_helpers
 from . import global_vars
 from . import lsp_helpers
 from . import node_client
+from .os_helpers import which
 
 # queue module name changed from Python 2 to 3
 if int(sublime.version()) < 3000:
@@ -27,7 +28,7 @@ class LspCommClient(node_client.CommClient):
     def __init__(self, binary_path, args, env, root_path):
         self.server_proc = None
         self.args = copy.deepcopy(args)
-        program = LspCommClient.which(binary_path)
+        program = which(binary_path)
         if program is None:
             program = binary_path
         self.args.insert(0, program)
@@ -220,69 +221,6 @@ class LspCommClient(node_client.CommClient):
     @staticmethod
     def is_executable(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    @staticmethod
-    def which(cmd, mode=os.F_OK | os.X_OK, path=None):
-        """Given a command, mode, and a PATH string, return the path which
-        conforms to the given mode on the PATH, or None if there is no such
-        file.
-
-        `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
-        of os.environ.get("PATH"), or can be overridden with a custom search
-        path.
-
-        """
-        # Check that a given file can be accessed with the correct mode.
-        # Additionally check that `file` is not a directory, as on Windows
-        # directories pass the os.access check.
-        def _access_check(fn, mode):
-            return (os.path.exists(fn) and os.access(fn, mode)
-                    and not os.path.isdir(fn))
-
-        # If we're given a path with a directory part, look it up directly rather
-        # than referring to PATH directories. This includes checking relative to the
-        # current directory, e.g. ./script
-        if os.path.dirname(cmd):
-            if _access_check(cmd, mode):
-                return cmd
-            return None
-
-        if path is None:
-            path = os.environ.get("PATH", os.defpath)
-        if not path:
-            return None
-        path = path.split(os.pathsep)
-
-        if sys.platform == "win32":
-            # The current directory takes precedence on Windows.
-            if not os.curdir in path:
-                path.insert(0, os.curdir)
-
-            # PATHEXT is necessary to check on Windows.
-            pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
-            # See if the given file matches any of the expected path extensions.
-            # This will allow us to short circuit when given "python.exe".
-            # If it does match, only test that one, otherwise we have to try
-            # others.
-            if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
-                files = [cmd]
-            else:
-                files = [cmd + ext for ext in pathext]
-        else:
-            # On other platforms you don't have things like PATHEXT to tell you
-            # what file suffixes are executable, so just pass on cmd as-is.
-            files = [cmd]
-
-        seen = set()
-        for dir in path:
-            normdir = os.path.normcase(dir)
-            if not normdir in seen:
-                seen.add(normdir)
-                for thefile in files:
-                    name = os.path.join(dir, thefile)
-                    if _access_check(name, mode):
-                        return name
-        return None
 
 
 class ServerClient(LspCommClient):

--- a/typescript/libs/lsp_client.py
+++ b/typescript/libs/lsp_client.py
@@ -310,7 +310,7 @@ class ServerClient(LspCommClient):
             print(err)
             self.server_proc = None
         # start reader thread
-        if self.server_proc and (not self.server_proc.poll()):
+        if self.server_proc and (self.server_proc.poll() is None):
             log.debug("server process " + str(self.server_proc.pid))
             log.debug("starting reader thread")
             readerThread = threading.Thread(target=ServerClient.__reader, args=(
@@ -331,13 +331,17 @@ class ServerClient(LspCommClient):
         while True:
             if LspCommClient.read_msg(stream, msgq, eventq, asyncReq, reqType, proc, eventHandlers):
                 log.debug("server exited")
+                proc.stderr.close()
                 return
 
     @staticmethod
     def __logger(stream, bar):
         """ Dumps server's stderr to stderr """
-        for line in iter(stream.readline, ""):
-            print(">" + line.decode("utf-8").rstrip(), file=sys.stderr)
+        try:
+            for line in iter(stream.readline, ""):
+                print(">" + line.decode("utf-8").rstrip(), file=sys.stderr)
+        except:
+            pass
 
 class WorkerClient(LspCommClient):
     stop_worker = False

--- a/typescript/libs/lsp_helpers.py
+++ b/typescript/libs/lsp_helpers.py
@@ -1,6 +1,12 @@
 from . import json_helpers
+import sublime
 import json
-
+if int(sublime.version()) < 3000:
+    import urllib
+    from urlparse import urljoin
+else:
+    import urllib.request as urllib
+    from urllib.parse import urljoin
 
 def init_message(root_path, process_id):
     cmd = {
@@ -126,8 +132,7 @@ def convert_filename_to_lsp(args, version=None):
 
 
 def filename_to_uri(filename):
-    return "file://"+filename
-
+    return urljoin('file:', urllib.pathname2url(filename))
 
 def convert_lsp_to_filename(uri):
     return uri[len("file://"):]

--- a/typescript/libs/lsp_helpers.py
+++ b/typescript/libs/lsp_helpers.py
@@ -1,6 +1,8 @@
 from . import json_helpers
 import sublime
 import json
+import sys
+
 if int(sublime.version()) < 3000:
     import urllib
     from urlparse import urljoin
@@ -135,8 +137,10 @@ def filename_to_uri(filename):
     return urljoin('file:', urllib.pathname2url(filename))
 
 def convert_lsp_to_filename(uri):
-    return uri[len("file://"):]
-
+    uri = uri[len("file://"):]
+    if sys.platform == "win32":
+        uri = uri.lstrip("/")
+    return uri
 
 def format_request(request):
     """Converts the request into json and adds the Content-Length header"""

--- a/typescript/libs/lsp_helpers.py
+++ b/typescript/libs/lsp_helpers.py
@@ -223,20 +223,27 @@ def convert_response(request_type, response):
         }
     elif request_type == "textDocument/references":
         referencesRespBody = {
-                "refs": [],
-                "symbolName": "SymbolName",
-                "symbolDisplayString": "SymbolText",
-                "symbolStartOffset": 17
-            }
+                "refs": []
+        }
+
+        helper = RefsHelper()
+        symbol = None
         for entry in response["result"]:
+            file = convert_lsp_to_filename(entry["uri"])
+            line = helper.lineText(file, entry["range"]["start"]["line"])
+            if symbol is None and entry["range"]["start"]["line"] == entry["range"]["end"]["line"]:
+                symbol = line[entry["range"]["start"]["character"]:entry["range"]["end"]["character"]]
             referencesRespBody["refs"].append({
                 "end": convert_position_from_lsp(entry["range"]["end"]),
                 "start": convert_position_from_lsp(entry["range"]["start"]),
                 "isDefinition": False,
                 "isWriteAccess": True,
-                "file": convert_lsp_to_filename(entry["uri"]),
-                "lineText": "RandomText",
+                "file": file,
+                "lineText": line
             })
+        if symbol is None:
+            symbol = "?"
+        referencesRespBody["symbolName"] = symbol
         return {
             "seq": 0,
             "request_seq": response["id"],
@@ -254,3 +261,42 @@ def convert_response(request_type, response):
 #         ref_display_string = args["referencesRespBody"]["symbolDisplayString"]
 #         ref_id = args["referencesRespBody"]["symbolName"]
 #         refs = args["referencesRespBody"]["refs"]
+
+class RefsHelper:
+
+    __lines = {}
+    __content = {}
+
+    def lineText(self, fileName, line):
+        """ returns text of the given line in the given file """
+        lines = self.__table(fileName)
+        l = len(lines)
+        if l < line:
+            return ''
+        content = self.__content[fileName]
+        start = lines[line]
+        if line < l - 1:
+            end = lines[line + 1]
+        else:
+            end = len(content)
+        return content[start:end].rstrip()
+
+    def __table(self, fileName):
+        """ returns line table for a given filename, computes if needed """
+        lines = self.__lines.get(fileName)
+        if lines is not None:
+            return lines
+        f = open(fileName)
+        lines = []
+        offset = 0
+        content = ''
+        try:
+            for line in f:
+                lines.append(offset)
+                offset += len(line)
+                content += line
+        finally:
+            f.close()
+            self.__lines[fileName] = lines
+            self.__content[fileName] = content
+        return lines

--- a/typescript/libs/os_helpers.py
+++ b/typescript/libs/os_helpers.py
@@ -1,0 +1,65 @@
+import os
+import sys
+
+# From shutil.which introduced in Python 3.3
+def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+
+    """
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode)
+                and not os.path.isdir(fn))
+
+    # If we're given a path with a directory part, look it up directly rather
+    # than referring to PATH directories. This includes checking relative to the
+    # current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+        return None
+
+    if path is None:
+        path = os.environ.get("PATH", os.defpath)
+    if not path:
+        return None
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if not os.curdir in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        normdir = os.path.normcase(dir)
+        if not normdir in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None

--- a/typescript/libs/view_helpers.py
+++ b/typescript/libs/view_helpers.py
@@ -97,7 +97,7 @@ def active_window():
 
 
 def is_supported_ext(view):
-    """Test if the outer syntactic scope is 'source.ts' or 'source.tsx' """
+    """Test if view's file format is supported """
     if not view.file_name():
         return False
 
@@ -105,7 +105,6 @@ def is_supported_ext(view):
         location = view.sel()[0].begin()
     except:
         return False
-
     for selector in cli.client_manager.extension_mapping.keys():
         if view.match_selector(location, "source.%s" % selector):
             return True


### PR DESCRIPTION
- Windows support (dealing with Windows-specific URI `file:///`, looking for LSP server executable in `PATH` while trying extensions from `PATHEXT`)
- Decorating results of "Find References" by using local file system data in a separate thread. We need to have some data not provided by the LSP protocol (such as matching lines text and symbol information) to construct "Find References" results page
- Added installation instructions for TypeScript/JavaScript
- Dumping LSP server's stderr messages